### PR TITLE
Various spacing issue fixes

### DIFF
--- a/desktop/es/errors.ftl
+++ b/desktop/es/errors.ftl
@@ -11,23 +11,23 @@ errors-standard-popup =
 errors-addons-active-popup =
     <h1>Error</h1>
     
-    <p> Se ha producido un error. Por favor inicia la Anki manteniendo presionadas ples teclas Mayús y la flecha hacia abajo, lo que desactivará temporalmente los extensiones que tienes instaladas. </p>
+    <p>Se ha producido un error. Por favor inicia la Anki manteniendo presionadas ples teclas Mayús y la flecha hacia abajo, lo que desactivará temporalmente los extensiones que tienes instaladas.</p>
     
-    <p> Si este error persiste sólo cuando tienes las extensiones activadas, utiliza Herramientas > Menú de Extensiones para deshabilitar alguna extensión y reinicia el Anki, repitiendo este proceso hasta que descubras qué extensión en concreto es la que causa el problema </p>
+    <p>Si este error persiste sólo cuando tienes las extensiones activadas, utiliza Herramientas > Menú de Extensiones para deshabilitar alguna extensión y reinicia el Anki, repitiendo este proceso hasta que descubras qué extensión en concreto es la que causa el problema</p>
     
-    <p> Cuando hayas descubierto la extensión que causaba el problema, por favor informa de esto a { -errors-addon-support-site }. </p>
+    <p>Cuando hayas descubierto la extensión que causaba el problema, por favor informa de esto a { -errors-addon-support-site }.</p>
     
-    <p>Información de depuración: </p>
+    <p>Información de depuración:</p>
 errors-accessing-db =
     Ha ocurrido un error accediendo a la base de datos.
     
     Posibles causas:
     
-    -  Un antivirus, cortafuegos o software para sincronizar archivos puede estar interfiriendo con Anki. Prueba a desactivarlos y mira si el problema desaparece.
+    - Un antivirus, cortafuegos o software para sincronizar archivos puede estar interfiriendo con Anki. Prueba a desactivarlos y mira si el problema desaparece.
     - Tu disco duro puede estar lleno.
-    -  La carpeta Documentos/Anki puede estar compartida en red.
+    - La carpeta Documentos/Anki puede estar compartida en red.
     - Los archivos en la carpeta Documentos/Anki pueden no tener permiso de escritura.
-    -  Tu disco duro puede tener errores.
+    - Tu disco duro puede tener errores.
     
     Es una buena idea ejecutar Herramientas>Comprobar base de datos para asegurar que tu colección no está corrupta.
 errors-unable-open-collection =

--- a/desktop/sv-SE/errors.ftl
+++ b/desktop/sv-SE/errors.ftl
@@ -4,11 +4,11 @@ errors-accessing-db =
     
     Möjligaorsaker:
     
-    -Antivirus-, brandvägg-, backup- eller synkroniseringsprogram kan störa Anki. Försök att avaktivera sådan programvara och se om problemet löses.
-    -Din hårddisk kan vara full.
-    -Mappen Dokument/Anki kan befinna sig på en nätverksenhet.
-    -Filer i mappen Dokument/Anki kan vara skrivskyddade.
-    -Din hårddisk kan ha defekter.
+    - Antivirus-, brandvägg-, backup- eller synkroniseringsprogram kan störa Anki. Försök att avaktivera sådan programvara och se om problemet löses.
+    - Din hårddisk kan vara full.
+    - Mappen Dokument/Anki kan befinna sig på en nätverksenhet.
+    - Filer i mappen Dokument/Anki kan vara skrivskyddade.
+    - Din hårddisk kan ha defekter.
     
     Det är en bra idé att köra Verktyg>Kontrollera Databas för att säkerställa att din samling inte är korrupt.
 errors-unable-open-collection =

--- a/desktop/sv-SE/errors.ftl
+++ b/desktop/sv-SE/errors.ftl
@@ -6,7 +6,7 @@ errors-accessing-db =
     
     -Antivirus-, brandvägg-, backup- eller synkroniseringsprogram kan störa Anki. Försök att avaktivera sådan programvara och se om problemet löses.
     -Din hårddisk kan vara full.
-    - Mappen Dokument/Anki kan befinna sig på en nätverksenhet.
+    -Mappen Dokument/Anki kan befinna sig på en nätverksenhet.
     -Filer i mappen Dokument/Anki kan vara skrivskyddade.
     -Din hårddisk kan ha defekter.
     


### PR DESCRIPTION
Fixed some spacing issues.

For a fuller check, run a regex script searching for double or more spaces between two non-space characters (and perhaps strip trailing whitespace too), and removing unnecessary spaces after colons as a new line is created by the { $cont }, so the space is redundant.

I think that checking for and using an already existing piece of automated software may be worth a shot, although the different languages may pose a problem with their individual punctuation grammar rules!